### PR TITLE
RNMT-955 Use fixed rate schedule for Executor

### DIFF
--- a/puree/src/main/java/com/cookpad/puree/internal/RetryableTaskRunner.java
+++ b/puree/src/main/java/com/cookpad/puree/internal/RetryableTaskRunner.java
@@ -33,7 +33,7 @@ public class RetryableTaskRunner {
         if (future != null) {
             future.cancel(false);
         }
-        future = executor.schedule(task, backoffCounter.timeInMillis(), TimeUnit.MILLISECONDS);
+        future = executor.scheduleAtFixedRate(task, backoffCounter.timeInMillis(), backoffCounter.timeInMillis(), TimeUnit.MILLISECONDS);
     }
 
     public synchronized void reset() {

--- a/puree/src/main/java/com/cookpad/puree/internal/RetryableTaskRunner.java
+++ b/puree/src/main/java/com/cookpad/puree/internal/RetryableTaskRunner.java
@@ -33,7 +33,7 @@ public class RetryableTaskRunner {
         if (future != null) {
             future.cancel(false);
         }
-        future = executor.scheduleAtFixedRate(task, backoffCounter.timeInMillis(), backoffCounter.timeInMillis(), TimeUnit.MILLISECONDS);
+        future = executor.schedule(task, backoffCounter.timeInMillis(), TimeUnit.MILLISECONDS);
     }
 
     public synchronized void reset() {
@@ -42,11 +42,6 @@ public class RetryableTaskRunner {
     }
 
     public synchronized void retryLater() {
-        if (backoffCounter.isRemainingRetryCount()) {
-            backoffCounter.incrementRetryCount();
-            startDelayed();
-        } else {
-            reset();
-        }
+        startDelayed();
     }
 }

--- a/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
@@ -76,14 +76,12 @@ public abstract class PureeBufferedOutput extends PureeOutput {
         emit(jsonLogs, new AsyncResult() {
             @Override
             public void success() {
-                flushTask.reset();
                 storage.delete(records);
                 storage.unlock();
             }
 
             @Override
             public void fail() {
-                flushTask.retryLater();
                 storage.unlock();
             }
         });


### PR DESCRIPTION
This allows Android to keep emitting batches on a (configurable) fixed interval rather than just on trigger. I also removed the one-shot retries since the logger will keep emitting batches in a stateless manner. The connection-aware improvements will be done on the OSLogger plugin itself.